### PR TITLE
Fix payment flow, auto config delivery

### DIFF
--- a/internal/telegram/bot.go
+++ b/internal/telegram/bot.go
@@ -116,6 +116,7 @@ func (s *Service) handleUpdate(upd tgbotapi.Update) {
 		if upd.Message.IsCommand() {
 			s.handleCommand(upd.Message)
 		} else {
+			s.handleReceiptMessage(upd.Message)
 			s.handleFeedbackMessage(upd.Message)
 		}
 		return


### PR DESCRIPTION
## Summary
- keep purchase state until receipt upload and store payment ID
- deliver configs immediately after user sends receipt
- include platform-aware config/QR sending helpers
- avoid re-creating subscriptions on approval

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684dcb43fdcc833080af1c35d1605254